### PR TITLE
Added profile-update-interval applying logic

### DIFF
--- a/lib/app/modules/profile_manager.dart
+++ b/lib/app/modules/profile_manager.dart
@@ -239,6 +239,7 @@ class ProfileSetting {
     ps.remark = remark;
     ps.patch = patch;
     ps.updateInterval = updateInterval;
+    ps.updateIntervalByProfile = updateIntervalByProfile;
     ps.update = update;
     ps.url = url;
     ps.userAgent = userAgent;
@@ -758,6 +759,20 @@ class ProfileManager {
         }
       }
       profile.updateSubscriptionTraffic(result.data);
+      if (result.data != null) {
+        final profileUpdateInterval = result.data!.value(
+          "profile-update-interval",
+        );
+        if (profileUpdateInterval != null) {
+          var pui = int.tryParse(profileUpdateInterval);
+          if (pui != null) {
+            if (pui < 1) {
+              pui = 1;
+            }
+            profile.updateIntervalByProfile = Duration(hours: pui);
+          }
+        }
+      }
     }
     await save();
     updating.remove(id);
@@ -772,12 +787,16 @@ class ProfileManager {
   static Future<void> updateByTicker() async {
     DateTime now = DateTime.now();
     for (var profile in _config.profiles) {
-      if (!profile.isRemote() || profile.updateInterval == null) {
+      if (!profile.isRemote()) {
+        continue;
+      }
+      final interval =
+          profile.updateIntervalByProfile ?? profile.updateInterval;
+      if (interval == null) {
         continue;
       }
       if (profile.update == null ||
-          now.difference(profile.update!).inSeconds >=
-              profile.updateInterval!.inSeconds) {
+          now.difference(profile.update!).inSeconds >= interval.inSeconds) {
         update(profile.id);
       }
     }

--- a/lib/screens/add_profile_by_url_screen.dart
+++ b/lib/screens/add_profile_by_url_screen.dart
@@ -45,7 +45,6 @@ class _AddProfileByUrlScreenState
   final _textControllerLink = TextEditingController();
   final _textControllerRemark = TextEditingController();
   Duration? _updateInterval = const Duration(hours: 24);
-  Duration? _updateIntervalByProfile; //todo profile-update-interval
   String _userAgent = "";
   bool _xhwid = false;
   String _decryptPassword = "";


### PR DESCRIPTION
## Apply profile-update-interval header to auto-update logic

The profile-update-interval response header was already being parsed on add, but the stored value was never actually used. This wires it up so the server-suggested interval takes effect, matching the format that is similar to Clash Verge Rev.

Changes:
- clone now copies updateIntervalByProfile (was missing).
- update re-reads profile-update-interval header on every update, not only on add.
- updateByTicker uses server interval if available, falls back to user interval.

I can't build the app to check it on macos/ios since I don't have the `libclash-vpn-service` dependency and it is not public.