### PR TITLE
fix(iOS): reconnect VPN after network changes

### DIFF
--- a/ios/clashmiWidget/clashmiWidgetControl.swift
+++ b/ios/clashmiWidget/clashmiWidgetControl.swift
@@ -25,6 +25,27 @@ struct clashmiWidgetControl: ControlWidget {
         VpnServiceHandler.shared.uiLocalizedDescription = "Clash Mi"
         VpnServiceHandler.shared.getState(result: {_ in })
     }
+
+    static func setOnDemandEnabled(_ enabled: Bool) async throws {
+        let managers = try await NETunnelProviderManager.loadAllFromPreferences()
+        guard let manager = managers.first(where: { manager in
+            let tunnelProtocol = manager.protocolConfiguration as? NETunnelProviderProtocol
+            return tunnelProtocol?.providerBundleIdentifier == bundleIdentifier
+        }) else {
+            return
+        }
+
+        if enabled {
+            let rule = NEOnDemandRuleConnect()
+            rule.interfaceTypeMatch = .any
+            manager.onDemandRules = [rule]
+        } else {
+            manager.onDemandRules = nil
+        }
+        manager.isOnDemandEnabled = enabled
+        try await manager.saveToPreferences()
+    }
+
     var body: some ControlWidgetConfiguration {
         StaticControlConfiguration(
             kind: Self.controlKind,
@@ -70,10 +91,20 @@ struct StartVPNServiceIntent: SetValueIntent {
     func perform() async throws -> some IntentResult {
         if await FileManager.default.fileExists(atPath: clashmiWidgetControl.configFile.path()) {
             if value {
-                VpnServiceHandler.shared.start(timeoutInSeconds: 30) { err in
+                let started = await withCheckedContinuation { continuation in
+                    VpnServiceHandler.shared.start(timeoutInSeconds: 30) { err in
+                        continuation.resume(returning: err == nil)
+                    }
+                }
+                if started {
+                    try? await clashmiWidgetControl.setOnDemandEnabled(true)
                 }
             } else {
-                VpnServiceHandler.shared.stop { err in
+                try? await clashmiWidgetControl.setOnDemandEnabled(false)
+                await withCheckedContinuation { continuation in
+                    VpnServiceHandler.shared.stop { _ in
+                        continuation.resume()
+                    }
                 }
             }
         }

--- a/lib/app/local_services/vpn_service.dart
+++ b/lib/app/local_services/vpn_service.dart
@@ -354,10 +354,8 @@ class VPNService {
       await stop();
       return ReturnResultError(content);
     }
-    if (Platform.isIOS || Platform.isMacOS) {
-      if (setting.alwayOn) {
-        await FlutterVpnService.setAlwaysOn(setting.alwayOn);
-      }
+    if (Platform.isIOS || (Platform.isMacOS && setting.alwayOn)) {
+      await FlutterVpnService.setAlwaysOn(true);
     }
 
     if (enable) {
@@ -408,10 +406,8 @@ class VPNService {
       await stop();
       return ReturnResultError(content);
     }
-    if (Platform.isIOS || Platform.isMacOS) {
-      if (setting.alwayOn) {
-        await FlutterVpnService.setAlwaysOn(setting.alwayOn);
-      }
+    if (Platform.isIOS || (Platform.isMacOS && setting.alwayOn)) {
+      await FlutterVpnService.setAlwaysOn(true);
     }
 
     if (SettingManager.getConfig().autoSetSystemProxy) {


### PR DESCRIPTION
## Summary

- Enable Connect On Demand after a successful iOS VPN start or restart.
- Preserve the existing opt-in behavior on macOS.
- Apply the same on-demand lifecycle to the iOS Control Center toggle.
- Disable on-demand rules before an explicit user stop.

## Why

When the active interface changes between Wi-Fi and cellular, NetworkExtension may terminate the packet tunnel. Clash Mi already calls `FlutterVpnService.setAlwaysOn`, but the call is gated by `setting.alwayOn`. That setting is not exposed by Clash Mi and defaults to `false`, so iOS has no persisted rule that can bring the tunnel back after a network change.

This is narrower than the network-specific routing and SSID automation requested in #41, #171, and #337. It only keeps a VPN session that the user explicitly started active until the user explicitly stops it.

The Control Center path is included because it starts and stops `VpnServiceHandler` directly instead of going through the Dart `VPNService` lifecycle.

## User impact

- After the user connects, iOS can restart the tunnel on the next network access following a Wi-Fi/cellular transition.
- Stopping from either the app or Control Center clears Connect On Demand first, so the VPN stays stopped.

## Validation

- `git diff --check`
- Type-checked the modified Control Widget source against the iOS 18 Simulator SDK with a minimal `VpnServiceHandler` test stub.
- Verified the app start/restart paths enable on-demand and the explicit stop paths disable it.

Not run: a full Flutter/Xcode build or a physical-device Wi-Fi/cellular transition. The public checkout references generated Flutter packages and sibling path dependencies that are not present in this checkout.
